### PR TITLE
upstream changes and move the demo to digitalocean

### DIFF
--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -5,6 +5,7 @@ fact_caching = jsonfile
 fact_caching_connection = /tmp/
 fact_caching_timeout = 3600
 inventory = hosts
+deprecation_warnings = false
 
 [ssh_connection]
 pipelining = True

--- a/playbooks/digitalocean_infra.yaml
+++ b/playbooks/digitalocean_infra.yaml
@@ -1,0 +1,83 @@
+# Copyright (c) 2022 The ARA Records Ansible authors
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Spin up infra on digitalocean
+  hosts: localhost
+  gather_facts: no
+  collections:
+    - community.digitalocean
+  module_defaults:
+    group/community.digitalocean.all:
+      oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
+  vars:
+    vm_name: infra.recordsansible.org
+  tasks:
+    - name: Set up SSH key
+      digital_ocean_sshkey:
+        name: dmsimard
+        ssh_pub_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO/2VZqMbJ7oC6cJkAQbGLboXz44I+B1+bUDetDvO9qM dmsimard@localhost
+      register: _key
+
+    - name: Create a tag to associate our resources with
+      digital_ocean_tag:
+        name: "{{ vm_name }}"
+        state: present
+
+    # Allows ICMP and TCP connections to port 22 (SSH), 80/443 (HTTP/S) from any source
+    # Allows outbound access to any destination for protocols tcp, udp and icmp
+    # It will be applied automatically to the VM because they have the same tag.
+    - name: Set up firewall
+      digital_ocean_firewall:
+        name: "{{ vm_name }}"
+        tags: ["{{ vm_name }}"]
+        inbound_rules:
+          - protocol: icmp
+            ports: "1-65535"
+            sources:
+              addresses: ["0.0.0.0/0", "::/0"]
+          - protocol: tcp
+            ports: "22"
+            sources:
+              addresses: ["0.0.0.0/0", "::/0"]
+          - protocol: tcp
+            ports: "80"
+            sources:
+              addresses: ["0.0.0.0/0", "::/0"]
+          - protocol: tcp
+            ports: "443"
+            sources:
+              addresses: ["0.0.0.0/0", "::/0"]
+        outbound_rules:
+          - protocol: tcp
+            ports: "1-65535"
+            destinations:
+              addresses: ["0.0.0.0/0", "::/0"]
+          - protocol: udp
+            ports: "1-65535"
+            destinations:
+              addresses: ["0.0.0.0/0", "::/0"]
+          - protocol: icmp
+            ports: "1-65535"
+            destinations:
+              addresses: ["0.0.0.0/0", "::/0"]
+
+    - name: Create a centos-stream 9 droplet with the ssh key and firewall
+      digital_ocean_droplet:
+        name: "{{ vm_name }}"
+        tags: ["{{ vm_name }}"]
+        unique_name: true
+        # for flavor, image, region names, etc: https://slugs.do-api.dev/
+        size: s-2vcpu-4gb-amd
+        image: centos-stream-9-x64
+        region: tor1
+        ssh_keys:
+          - "{{ _key.data.ssh_key.id }}"
+        wait_timeout: 180
+      register: _droplet
+
+    - name: Set up an inventory host for the droplet
+      add_host:
+        hostname: "{{ vm_name }}"
+        ansible_ssh_host: >-
+          {{ (_droplet.data.droplet.networks.v4 | selectattr("type", "equalto", "public")).0.ip_address }}
+        ansible_ssh_user: root

--- a/playbooks/host_vars/infra.recordsansible.org.yaml
+++ b/playbooks/host_vars/infra.recordsansible.org.yaml
@@ -1,0 +1,65 @@
+# For ara_api and ara_frontend_nginx
+ara_api_allowed_hosts:
+  - demo.recordsansible.org
+ara_api_database_conn_max_age: 120
+ara_api_database_engine: django.db.backends.mysql
+ara_api_database_name: ara
+ara_api_database_host: 127.0.0.1
+ara_api_database_password: !vault |
+          $ANSIBLE_VAULT;1.1;AES256
+          34303538313430323138636534393566313139323766663266633363666265303336383132363137
+          6463643036363434383036383265363363366262353966640a333232393431373862613163616539
+          35646664396537356162373533363562343532633735393464636530346131646363633266396331
+          6530376562326235650a366666373330326565653938343766366433646437653866646531386661
+          38653236313130643333383232343130613765613263383263363634633834376238343430623561
+          6531633736656461376536306434626562303935333734346237
+ara_api_database_port: 3306
+ara_api_database_user: ara
+# TODO: must support read-only: https://github.com/ansible-community/ara-collection/issues/50
+# ara_api_external_auth: true
+# ara_api_external_auth_file: /etc/nginx/.htpasswd
+# ara_api_external_auth_users:
+#   - username: "{{ ara_api_username }}"
+#     password: "{{ ara_api_password }}"
+ara_api_fqdn: demo.recordsansible.org
+ara_api_frontend_server: nginx
+ara_api_frontend_ssl_cert: /etc/letsencrypt/live/demo.recordsansible.org/cert.pem
+ara_api_frontend_ssl_key: /etc/letsencrypt/live/demo.recordsansible.org/privkey.pem
+ara_api_frontend_ssl: true
+# We can set it to false once we can handle it via external_auth for better performance
+ara_api_write_login_required: true
+ara_api_wsgi_server: gunicorn
+
+# The size of a single result can be large if there are thousands of lines of output
+ara_nginx_client_max_body_size: "20M"
+
+# For geerlingguy.mysql
+# https://github.com/geerlingguy/ansible-role-mysql
+mysql_innodb_buffer_pool_size: "1024M"
+mysql_innodb_log_file_size: "256M"
+mysql_user_password: !vault |
+          $ANSIBLE_VAULT;1.1;AES256
+          35393463353937323335386535353731393636326230316530343439326136353039306562303164
+          3165653034666237303434376533613565333133646566640a323931336262666162356332646665
+          30346334363764616137666633373333373138653366613633383662396237316530636236313139
+          6335353234386434320a366166343037663262653961376631336132336663336161656436623039
+          31343361613166373161616463656365396231336132636538656161316466323738356637653665
+          6430373033316562396533333061326135373831643564366535
+mysql_root_password: !vault |
+          $ANSIBLE_VAULT;1.1;AES256
+          38636138373433333662633931313836353038636634363634653830616531393434373265383336
+          3561646331383462343361363566653239303032373063330a666166303964383636316137626436
+          38353136623539666135613738383166623639616534346237313065646535303634383930363265
+          3036646664306638340a356162356535633532393966363565363039636232656437393631623033
+          31616261376332666635393164616664333831663336393838373831636238663931643031343932
+          3164323863396137366531373035303231666134626162343266
+mysql_max_connections: 100
+mysql_databases:
+  - name: "{{ ara_api_database_name }}"
+    collation: "{{ ara_api_database_collation | default('utf8mb4_general_ci') }}"
+    encoding: "{{ ara_api_database_encoding | default('utf8mb4') }}"
+mysql_users:
+  - name: "{{ ara_api_database_user }}"
+    host: "{{ ara_api_database_host }}"
+    password: "{{ ara_api_database_password }}"
+    priv: "*.*:ALL"

--- a/playbooks/hosts
+++ b/playbooks/hosts
@@ -1,1 +1,1 @@
-demo.recordsansible.org ansible_host=139.178.83.37 ansible_user=fedora ansible_python_interpreter=/usr/bin/python3
+# This is empty, the inventory is generated inside the playbooks

--- a/playbooks/live-demo.yaml
+++ b/playbooks/live-demo.yaml
@@ -1,26 +1,19 @@
-- name: Provision demo.recordsansible.org
-  hosts: demo.recordsansible.org
+# Copyright (c) 2022 The ARA Records Ansible authors
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# See host_vars/infra.recordsansible.org.yaml for role variables
+- name: Provision the live demo for demo.recordsansible.org
+  hosts: infra.recordsansible.org
   gather_facts: yes
-  vars:
-    # ara_api
-    ara_api_write_login_required: true
-    ara_api_fqdn: api.demo.recordsansible.org
-    ara_api_frontend_server: nginx
-    ara_api_frontend_vhost: api.demo.recordsansible.org.conf.j2
-    ara_api_wsgi_server: gunicorn
-    ara_api_allowed_hosts:
-      - api.demo.recordsansible.org
-    # TODO: Figure out if it's possible to set ara-web to use demo from localhost:3000
-    ara_api_cors_origin_allow_all: true
-    ara_api_cors_origin_whitelist:
-      - https://web.demo.recordsansible.org
-      - http://logs.openstack.org
-      - http://localhost:3000
-    # ara_web
-    ara_web_fqdn: web.demo.recordsansible.org
-    ara_web_api_endpoint: "https://api.demo.recordsansible.org"
-    ara_web_frontend_server: nginx
-    ara_web_frontend_vhost: web.demo.recordsansible.org.conf.j2
-  roles:
-    - ara_api
-    - ara_web
+  tasks:
+    - name: Install and configure MySQL (thanks geerlingguy!)
+      include_role:
+        name: geerlingguy.mysql
+        # The role expects to run as root
+        apply:
+          become: true
+
+    # This role elevates privileges by itself only when necessary
+    - name: Deploy an ara API server with gunicorn and nginx in front
+      include_role:
+        name: recordsansible.ara.ara_api

--- a/playbooks/site.yaml
+++ b/playbooks/site.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 The ARA Records Ansible authors
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_playbook: digitalocean_infra.yaml
+- import_playbook: live-demo.yaml
+# TODO (need to update and migrate from fedora to centos):
+# - import_playbook: website.yaml


### PR DESCRIPTION
The website and live demo have been hosted on digitalocean for a while but the changes had not yet been comitted because I was busy.

This brings a much needed update to the live demo playbook which still referenced ara-web :grimacing: 

In a nutshell:
- It spins up a VM on digitalocean including ssh key and firewall
- It installs MySQL
- It deploys the latest version of ara with gunicorn and nginx in front

The website role needs a bit more work, it will come later.